### PR TITLE
Add CLI subcommands (`fix`, `check` and `print`)

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -43,7 +43,8 @@ fn fix_works() -> Result<(), Error> {
     let original = include_str!("data/input/i32.wat");
     let expected = include_str!("data/output/default/i32.wat");
 
-    let temp_path = env::temp_dir().join("out.wat")
+    let temp_path = env::temp_dir()
+        .join("out.wat")
         .into_os_string()
         .into_string()
         .unwrap();
@@ -61,8 +62,7 @@ fn fix_works() -> Result<(), Error> {
 fn check_works() {
     let source = include_str!("data/input/i32.wat");
     let formatted = include_str!("data/output/default/i32.wat");
-    let result =
-        wasmfmt(&["check", "tests/data/input/i32.wat"]).expect("failed to check i32.wat");
+    let result = wasmfmt(&["check", "tests/data/input/i32.wat"]).expect("failed to check i32.wat");
     assert!(result.contains("Difference found."));
     assert!(result.contains("Source:"));
     assert!(result.contains(source));
@@ -73,7 +73,6 @@ fn check_works() {
 #[test]
 fn print_works() {
     let formatted = include_str!("data/output/default/i32.wat");
-    let result =
-        wasmfmt(&["print", "tests/data/input/i32.wat"]).expect("failed to print i32.wat");
+    let result = wasmfmt(&["print", "tests/data/input/i32.wat"]).expect("failed to print i32.wat");
     assert_eq!(result, formatted);
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,7 +2,7 @@ use assert_matches::assert_matches;
 use pretty_assertions::assert_eq;
 use std::env;
 use std::fs;
-use std::io::{Error, Write};
+use std::io::Error;
 use std::process::{Command, Stdio};
 use wast::{
     parser::{self, ParseBuffer},
@@ -33,57 +33,36 @@ fn wasmfmt(args: &[&str]) -> Result<String, String> {
     }
 }
 
-fn wasmfmt_stdin(input: &str) -> Result<String, String> {
-    let mut process = Command::new(BIN)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("failed to spawn process");
-
-    let stdin = process
-        .stdin
-        .as_mut()
-        .expect("failed to get stdin handle from process");
-
-    stdin
-        .write_all(input.as_bytes())
-        .expect("failed to write to stdin");
-
-    stdin.flush().unwrap();
-
-    let output = process
-        .wait_with_output()
-        .expect("failed to get process output");
-
-    let stdout = String::from_utf8(output.stdout).expect("stdout");
-    let stderr = String::from_utf8(output.stderr).expect("stderr");
-
-    if !stderr.is_empty() {
-        Err(stderr)
-    } else {
-        Ok(stdout)
-    }
-}
-
 fn parse(input: &str) -> Result<(), WastError> {
     let buffer = ParseBuffer::new(input).unwrap();
     parser::parse::<Wat>(&buffer).map(|_| ())
 }
 
 #[test]
-fn fix_mode_works() {
+fn fix_works() -> Result<(), Error> {
+    let original = include_str!("data/input/i32.wat");
     let expected = include_str!("data/output/default/i32.wat");
-    let actual = wasmfmt(&["tests/data/input/i32.wat"]).expect("failed to format i32.wat");
+
+    let temp_path = env::temp_dir().join("out.wat")
+        .into_os_string()
+        .into_string()
+        .unwrap();
+    let _ = fs::write(&temp_path, original)?;
+    let _ = wasmfmt(&["fix", &temp_path]).expect("failed to format i32.wat");
+    let actual = fs::read_to_string(&temp_path).expect("read temp file");
+    let _ = fs::remove_file(&temp_path)?;
+
     assert_eq!(actual, expected);
     assert_matches!(parse(&actual), Ok(..));
+    Ok(())
 }
 
 #[test]
-fn check_mode_works() {
+fn check_works() {
     let source = include_str!("data/input/i32.wat");
     let formatted = include_str!("data/output/default/i32.wat");
     let result =
-        wasmfmt(&["tests/data/input/i32.wat", "--mode", "check"]).expect("failed to check i32.wat");
+        wasmfmt(&["check", "tests/data/input/i32.wat"]).expect("failed to check i32.wat");
     assert!(result.contains("Difference found."));
     assert!(result.contains("Source:"));
     assert!(result.contains(source));
@@ -92,29 +71,9 @@ fn check_mode_works() {
 }
 
 #[test]
-fn writes_to_output_file() -> Result<(), Error> {
+fn print_works() {
     let formatted = include_str!("data/output/default/i32.wat");
-    let tmp = env::temp_dir();
-    let out = tmp.join("out.wat");
-    let result = wasmfmt(&[
-        "tests/data/input/i32.wat",
-        "--output",
-        out.to_str().unwrap(),
-    ])
-    .expect("failed to format i32.wat");
-    let content = fs::read_to_string(&out)?;
-    assert_eq!(content, formatted);
-    assert_eq!(result, String::new());
-    fs::remove_file(out)?;
-    Ok(())
-}
-
-#[test]
-fn reads_from_stdin_if_no_file_is_provided() -> Result<(), Error> {
-    let source = include_str!("data/input/i32.wat");
-    let expected = include_str!("data/output/default/i32.wat");
-    let actual = wasmfmt_stdin(source).expect("failed to format i32.wat");
-    assert_eq!(actual, expected);
-    assert_matches!(parse(&actual), Ok(..));
-    Ok(())
+    let result =
+        wasmfmt(&["print", "tests/data/input/i32.wat"]).expect("failed to print i32.wat");
+    assert_eq!(result, formatted);
 }


### PR DESCRIPTION
Adds three new CLI subcommands, replacing the `--mode` flag:

- `wasmfmt print`: format the input file, and print it to `stdout`
- `wasmfmt check`: format the input file, and check it against the original content (corresponds to `wasmfmt --mode check`)
- `wasmfmt fix`: format the input file, and overwrite the file content